### PR TITLE
Fix build error on Windows

### DIFF
--- a/.github/workflows/apt.yml
+++ b/.github/workflows/apt.yml
@@ -24,7 +24,7 @@ jobs:
             test-script: ci/apt-test.sh
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: rake compile & rake test
         run: |
           docker run \

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,13 +6,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.0'
     - name: Run the default task
       run: |
-        gem install bundler -v 2.2.26
         bundle install
         bundle exec rake

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,13 +6,12 @@ jobs:
   build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.0'
     - name: Run the default task
       run: |
-        gem install bundler -v 2.2.26
         bundle install
         bundle exec rake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,7 @@ jobs:
         ruby-version: '3.0'
     - name: Run the default task
       run: |
+        pacman -Syyu --noconfirm
         cmake --version
         ridk exec bundle install
         ridk exec bundle exec rake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,13 +6,13 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.0'
     - name: Run the default task
       run: |
-        gem install bundler -v 2.2.26
+        cmake --version
         ridk exec bundle install
         ridk exec bundle exec rake

--- a/.github/workflows/yum.yml
+++ b/.github/workflows/yum.yml
@@ -9,15 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         label:
-          - CentOS 7 x86_64
           - RockyLinux OS 8 x86_64
           - RockyLinux OS 9 x86_64
           - Fedora 37 x86_64
           - AmazonLinux 2 x86_64
         include:
-          - label: CentOS 7 x86_64
-            test-docker-image: centos:7
-            test-script: ci/yum-test.sh
           - label: RockyLinux OS 8 x86_64
             test-docker-image: rockylinux:8
             test-script: ci/yum-test.sh
@@ -32,7 +28,7 @@ jobs:
             test-script: ci/yum-test.sh
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: rake compile & rake test
         run: |
           docker run \

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,4 @@
 /ext/cmetrics/*.a
 /lib/cmetrics/cmetrics.so
 /lib/cmetrics/cmetrics.bundle
-/ext/cmetrics/cmetrics/
-/ext/cmetrics/monkey/
-/ext/cmetrics/mpack/
+ext/cmetrics/

--- a/ci/apt-test.sh
+++ b/ci/apt-test.sh
@@ -35,6 +35,6 @@ apt install -V -y lsb-release
 
 apt install -V -y ruby-dev git build-essential pkg-config cmake
 cd /cmetrics-ruby && \
-    gem install bundler --no-document && \
+    gem install bundler -v 2.4.22 --no-document && \
     bundle install && \
     bundle exec rake

--- a/ci/yum-test.sh
+++ b/ci/yum-test.sh
@@ -93,5 +93,5 @@ else
     if [ $USE_AMZN_EXT -eq 1 ]; then
         echo 'gem "io-console"' > /cmetrics-ruby/Gemfile.local
     fi
-    cd /cmetrics-ruby && gem install bundler --no-document && bundle install && bundle exec rake
+    cd /cmetrics-ruby && gem install bundler -v 2.4.22 --no-document && bundle install && bundle exec rake
 fi

--- a/ext/cmetrics/extconf.rb
+++ b/ext/cmetrics/extconf.rb
@@ -44,6 +44,10 @@ class BuildCMetrics
     @fluent_otel_version = fluent_otel_version
     @cfl_version = cfl_version
     @recipe = MiniPortileCMake.new("cmetrics", @version, **kwargs)
+    def @recipe.cmake_compile_flags
+      flags = super
+      flags << "-DCMAKE_C_FLAGS='-Wno-incompatible-pointer-types'"
+    end
     @checkpoint = ".#{@recipe.name}-#{@recipe.version}.installed"
     @recipe.target = File.join(ROOT, "ports")
     @recipe.files << {


### PR DESCRIPTION
This patch will fix following build error:

```
PS C:\src\calyptia-cmetrics-ruby> rake
cd tmp/x64-mingw-ucrt/cmetrics/3.3.6
C:/Ruby33-x64/bin/ruby.exe -I. ../../../../ext/cmetrics/extconf.rb
checking for whether cmake3 or cmake is usable... cmake
Extracting v0.5.9 into tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9... OK
Extracting v0.2.0 into tmp/x86_64-w64-mingw32/ports/cfl/0.2.0... OK
Extracting v0.9.0 into tmp/x86_64-w64-mingw32/ports/fluent-otel-proto/0.9.0... OK
Running 'configure' for cmetrics 0.5.9... OK
Running 'compile' for cmetrics 0.5.9... ERROR. Please review logs to see what happened:
----- contents of 'C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/compile.log' -----
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[  1%] Building C object lib/cfl/lib/xxhash/cmake_unofficial/CMakeFiles/xxhash.dir/__/xxhash.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[  3%] Linking C static library libxxhash.a
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[  3%] Built target xxhash
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[  5%] Building C object lib/cfl/src/CMakeFiles/cfl-static.dir/cfl.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[  7%] Building C object lib/cfl/src/CMakeFiles/cfl-static.dir/cfl_log.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[  9%] Building C object lib/cfl/src/CMakeFiles/cfl-static.dir/cfl_sds.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 11%] Building C object lib/cfl/src/CMakeFiles/cfl-static.dir/cfl_time.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 13%] Building C object lib/cfl/src/CMakeFiles/cfl-static.dir/cfl_kv.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 15%] Building C object lib/cfl/src/CMakeFiles/cfl-static.dir/cfl_kvlist.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 17%] Building C object lib/cfl/src/CMakeFiles/cfl-static.dir/cfl_array.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 19%] Building C object lib/cfl/src/CMakeFiles/cfl-static.dir/cfl_variant.c.obj
bash.exe: warning: could not find /tmp, please create!
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/cfl/src/cfl_variant.c: In function 'cfl_variant_print':
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/cfl/src/cfl_variant.c:26:23: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'void *' [-Wformat=]
   26 | #define HEXDUMPFORMAT "%#x"
      |                       ^~~~~
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/cfl/src/cfl_variant.c:67:27: note: in expansion of macro 'HEXDUMPFORMAT'
   67 |         ret = fprintf(fp, HEXDUMPFORMAT, val->data.as_reference);
      |                           ^~~~~~~~~~~~~
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/cfl/src/cfl_variant.c:26:26: note: format string is defined here
   26 | #define HEXDUMPFORMAT "%#x"
      |                        ~~^
      |                          |
      |                          unsigned int
      |                        %#p
bash.exe: warning: could not find /tmp, please create!
[ 21%] Linking C static library libcfl.a
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 21%] Built target cfl-static
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 23%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/fluent-otel.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 25%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/__/proto_c/protobuf-c/protobuf-c.c.obj
bash.exe: warning: could not find /tmp, please create!
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/fluent-otel-proto/proto_c/protobuf-c/protobuf-c.c: In function 'repeated_field_pack_to_buffer':
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/fluent-otel-proto/proto_c/protobuf-c/protobuf-c.c:1919:24: warning: variable 'tmp' set but not used [-Wunused-but-set-variable]
 1919 |                 size_t tmp;
      |                        ^~~
bash.exe: warning: could not find /tmp, please create!
[ 26%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/__/proto_c/opentelemetry/proto/common/v1/common.pb-c.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 28%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/__/proto_c/opentelemetry/proto/resource/v1/resource.pb-c.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 30%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/__/proto_c/opentelemetry/proto/trace/v1/trace.pb-c.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 32%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/edf9bc46171d1710c54dc278027f1488/trace/v1/trace_service.pb-c.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 34%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/__/proto_c/opentelemetry/proto/logs/v1/logs.pb-c.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 36%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/edf9bc46171d1710c54dc278027f1488/logs/v1/logs_service.pb-c.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 38%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/__/proto_c/opentelemetry/proto/metrics/v1/metrics.pb-c.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 40%] Building C object lib/fluent-otel-proto/src/CMakeFiles/fluent-otel-proto.dir/ba6f9e88a390ffdf0ff32e637c09d645/v1/metrics_service.pb-c.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 42%] Linking C static library libfluent-otel-proto.a
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 42%] Built target fluent-otel-proto
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 46%] Built target mpack-static
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 48%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_gauge.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 50%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_counter.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 51%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_untyped.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 53%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_summary.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 55%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_histogram.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 57%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_metric.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 59%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_metric_histogram.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 61%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_map.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 63%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_log.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 65%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_opts.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 67%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_label.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 69%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_cat.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 71%] Building C object src/CMakeFiles/cmetrics-static.dir/cmetrics.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 73%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_encode_opentelemetry.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 75%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_decode_opentelemetry.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 76%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_encode_prometheus.c.obj
bash.exe: warning: could not find /tmp, please create!
In function 'append_metric_value',
    inlined from 'format_metric' at C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus.c:298:5:
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus.c:193:15: warning: 'val' may be used uninitialized [-Wmaybe-uninitialized]
  193 |         len = snprintf(tmp, sizeof(tmp) - 1, " %.17g\n", val);
      |               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus.c: In function 'format_metric':
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus.c:142:12: note: 'val' was declared here
  142 |     double val;
      |            ^~~
bash.exe: warning: could not find /tmp, please create!
[ 78%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_encode_prometheus_remote_write.c.obj
bash.exe: warning: could not find /tmp, please create!
In file included from C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/cfl/include/cfl/cfl.h:32,
                 from C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/include/cmetrics/cmetrics.h:40,
                 from C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus_remote_write.c:19:
In function '__cfl_list_add',
    inlined from 'cfl_list_add' at C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/cfl/include/cfl/cfl_list.h:73:5,
    inlined from 'pack_complex_type' at C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus_remote_write.c:1012:5:
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/lib/cfl/include/cfl/cfl_list.h:64:16: warning: storing the address of local variable 'additional_label' in '((struct cfl_list *)map)[11].prev' [-Wdangling-pointer=]
   64 |     next->prev = _new;
      |     ~~~~~~~~~~~^~~~~~
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus_remote_write.c: In function 'pack_complex_type':
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus_remote_write.c:994:27: note: 'additional_label' declared here
  994 |     struct cmt_map_label  additional_label;
      |                           ^~~~~~~~~~~~~~~~
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_prometheus_remote_write.c:992:39: note: 'map' declared here
  992 |                       struct cmt_map *map)
      |                       ~~~~~~~~~~~~~~~~^~~
bash.exe: warning: could not find /tmp, please create!
[ 80%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_encode_splunk_hec.c.obj
bash.exe: warning: could not find /tmp, please create!
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_splunk_hec.c: In function 'format_context_common':
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_encode_splunk_hec.c:143:68: warning: format '%lu' expects argument of type 'long unsigned int', but argument 4 has type 'time_t' {aka 'long long int'} [-Wformat=]
  143 |     len = snprintf(timestamp, sizeof(timestamp) - 1, "\"time\":%09lu.%09lu,", tms.tv_sec, tms.tv_nsec);
      |                                                                ~~~~^          ~~~~~~~~~~
      |                                                                    |             |
      |                                                                    |             time_t {aka long long int}
      |                                                                    long unsigned int
      |                                                                %09llu
bash.exe: warning: could not find /tmp, please create!
[ 82%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_encode_text.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 84%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_encode_influx.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 86%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_encode_msgpack.c.obj
bash.exe: warning: could not find /tmp, please create!
bash.exe: warning: could not find /tmp, please create!
[ 88%] Building C object src/CMakeFiles/cmetrics-static.dir/cmt_decode_msgpack.c.obj
bash.exe: warning: could not find /tmp, please create!
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_decode_msgpack.c: In function 'unpack_basic_type_meta':
C:/src/calyptia-cmetrics-ruby/tmp/x64-mingw-ucrt/cmetrics/3.3.6/tmp/x86_64-w64-mingw32/ports/cmetrics/0.5.9/cmetrics-0.5.9/src/cmt_decode_msgpack.c:998:21: error: assignment to 'struct cmt_counter *' from incompatible pointer type 'struct counter *' [-Wincompatible-pointer-types]
  998 |             counter = (struct counter *) decode_context->map->parent;
      |                     ^
make[2]: *** [src/CMakeFiles/cmetrics-static.dir/build.make:410: src/CMakeFiles/cmetrics-static.dir/cmt_decode_msgpack.c.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:435: src/CMakeFiles/cmetrics-static.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
----- end of file -----
*** ../../../../ext/cmetrics/extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
        --with-opt-dir
        --without-opt-dir
        --with-opt-include=${opt-dir}/include
        --without-opt-include
        --with-opt-lib=${opt-dir}/lib
        --without-opt-lib
        --with-make-prog
        --without-make-prog
        --srcdir=../../../../ext/cmetrics
        --curdir
        --ruby=C:/Ruby33-x64/bin/$(RUBY_BASE_NAME)
C:/Ruby33-x64/lib/ruby/gems/3.3.0/gems/mini_portile2-2.8.7/lib/mini_portile2/mini_portile.rb:623:in `block in execute': Failed to complete compile task (RuntimeError)
        from C:/Ruby33-x64/lib/ruby/gems/3.3.0/gems/mini_portile2-2.8.7/lib/mini_portile2/mini_portile.rb:589:in `chdir'
        from C:/Ruby33-x64/lib/ruby/gems/3.3.0/gems/mini_portile2-2.8.7/lib/mini_portile2/mini_portile.rb:589:in `execute'
        from C:/Ruby33-x64/lib/ruby/gems/3.3.0/gems/mini_portile2-2.8.7/lib/mini_portile2/mini_portile.rb:194:in `compile'
        from ../../../../ext/cmetrics/extconf.rb:121:in `build'
        from ../../../../ext/cmetrics/extconf.rb:145:in `<main>'
rake aborted!
Command failed with status (1): [C:/Ruby33-x64/bin/ruby.exe -I. ../../../../ext/cmetrics/extconf.rb]

Tasks: TOP => default => compile => compile:x64-mingw-ucrt => compile:cmetrics:x64-mingw-ucrt => copy:cmetrics:x64-mingw-ucrt:3.3.6 => tmp/x64-mingw-ucrt/cmetrics/3.3.6/cmetrics.so => tmp/x64-mingw-ucrt/cmetrics/3.3.6/Makefile
(See full trace by running task with --trace)
```

### Environment
```
PS C:\src\calyptia-cmetrics-ruby> ruby -v
ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [x64-mingw-ucrt]
PS C:\src\calyptia-cmetrics-ruby> gcc -v
Using built-in specs.
COLLECT_GCC=C:\Ruby33-x64\msys64\ucrt64\bin\gcc.exe
COLLECT_LTO_WRAPPER=C:/Ruby33-x64/msys64/ucrt64/bin/../lib/gcc/x86_64-w64-mingw32/14.2.0/lto-wrapper.exe
Target: x86_64-w64-mingw32
Configured with: ../gcc-14.2.0/configure --prefix=/ucrt64 --with-local-prefix=/ucrt64/local --build=x86_64-w64-mingw32 --host=x86_64-w64-mingw32 --target=x86_64-w64-mingw32 --with-native-system-header-dir=/ucrt64/include --libexecdir=/ucrt64/lib --enable-bootstrap --enable-checking=release --with-arch=nocona --with-tune=generic --enable-languages=c,lto,c++,fortran,ada,objc,obj-c++,rust,jit --enable-shared --enable-static --enable-libatomic --enable-threads=posix --enable-graphite --enable-fully-dynamic-string --enable-libstdcxx-filesystem-ts --enable-libstdcxx-time --disable-libstdcxx-pch --enable-lto --enable-libgomp --disable-libssp --disable-multilib --disable-rpath --disable-win32-registry --disable-nls --disable-werror --disable-symvers --with-libiconv --with-system-zlib --with-gmp=/ucrt64 --with-mpfr=/ucrt64 --with-mpc=/ucrt64 --with-isl=/ucrt64 --with-pkgversion='Rev1, Built by MSYS2 project' --with-bugurl=https://github.com/msys2/MINGW-packages/issues --with-gnu-as --with-gnu-ld --disable-libstdcxx-debug --enable-plugin --with-boot-ldflags=-static-libstdc++ --with-stage1-ldflags=-static-libstdc++
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 14.2.0 (Rev1, Built by MSYS2 project)
```